### PR TITLE
point main to ./src/propeller.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "Propeller",
   "version": "0.3.1",
   "description": "JavaScript library to rotate elements by mouse with inertia or without it.",
-  "main": "index.js",
+  "main": "./src/propeller.js",
   "directories": {
     "example": "example"
   },


### PR DESCRIPTION
main points to non existing file index.js.

it is possible to require/import it in the application by using a full path:

import Propeller from "Propeller/src/propeller"

by pointing main to the correct file it becomes more ideomatic to use:

import Propeller from "Propeller"
